### PR TITLE
Modify NodeJS example to check `sub`, `iss`, and `aud` in userinfo request

### DIFF
--- a/examples/nodejs/src/router.mjs
+++ b/examples/nodejs/src/router.mjs
@@ -66,7 +66,7 @@ router.get('/callback', async function handleSingpassCallback(ctx) {
     console.log(tokenSet.claims());
 
     // Userinfo request (available only to apps with additional allowed scopes, beyond just 'openid').
-    const userInfo = await singpassClient.userinfo(tokenSet.access_token);
+    const userInfo = await singpassClient.userinfo(tokenSet);
     console.log('This is the user info returned:');
     console.log(userInfo);
 


### PR DESCRIPTION
If we pass the entire `tokenset` to the `userinfo()` call, `node-openid-client` will correctly perform the `sub`, `iss`, and `aud` checks required by the OIDC spec.