### PR TITLE
Fix Node example's client config's `id_token_signed_response_alg` value

### DIFF
--- a/examples/nodejs/src/router.mjs
+++ b/examples/nodejs/src/router.mjs
@@ -9,10 +9,12 @@ const singpassIssuer = await Issuer.discover(config.ISSUER_URL);
 
 const singpassClient = new singpassIssuer.Client(
   {
+    // All the hardcoded values used below are taken from Singpass' OpenID Provider Metadata,
+    // which can be found at config.ISSUER_URL + '/.well-known/openid-configuration'
     client_id: config.CLIENT_ID,
     response_types: ['code'],
     token_endpoint_auth_method: 'private_key_jwt',
-    id_token_signed_response_alg: config.KEYS.PRIVATE_SIG_KEY.alg,
+    id_token_signed_response_alg: 'ES256',
     userinfo_encrypted_response_alg: config.KEYS.PRIVATE_ENC_KEY.alg,
     userinfo_encrypted_response_enc: 'A256GCM',
     userinfo_signed_response_alg: config.KEYS.PRIVATE_SIG_KEY.alg,


### PR DESCRIPTION
The client config in the NodeJS example was incorrectly using the demo app's own signing key's `alg` where Singpass' signing key's `alg` should have been used. 