### PR TITLE
Fix Node example's client config options

### DIFF
--- a/examples/nodejs/src/router.mjs
+++ b/examples/nodejs/src/router.mjs
@@ -17,7 +17,10 @@ const singpassClient = new singpassIssuer.Client(
     id_token_signed_response_alg: 'ES256',
     userinfo_encrypted_response_alg: config.KEYS.PRIVATE_ENC_KEY.alg,
     userinfo_encrypted_response_enc: 'A256GCM',
-    userinfo_signed_response_alg: config.KEYS.PRIVATE_SIG_KEY.alg,
+    userinfo_signed_response_alg: 'ES256',
+    // The following two fields are only required if the client's (RP) profile is 'direct_pii_allowed'.
+    // id_token_encrypted_response_alg: config.KEYS.PRIVATE_ENC_KEY.alg,
+    // id_token_encrypted_response_enc: 'A256CBC-HS512',
   },
   { keys: [config.KEYS.PRIVATE_SIG_KEY, config.KEYS.PRIVATE_ENC_KEY] }
 );


### PR DESCRIPTION
This PR fixes the following issues in the current client config from the Node example:
1. The `userinfo_signed_response_alg` should follow that in the OpenID discovery endpoint.
1. If the RP supports receiving PII in the `id_token`, and hence receives a JWS in JWE rather than a plain JWS back from the token endpoint, then the client must be instantiated with the `id_token_encrypted_response_alg` and `id_token_encrypted_response_enc` options for proper decryption of the JWE. 
Otherwise, `openid-client` will throw the following error `RPError: failed to decode JWT (TypeError: encrypted JWTs cannot be decoded)`